### PR TITLE
a new function that should reduce coverage on a new PR

### DIFF
--- a/walrus/api.py
+++ b/walrus/api.py
@@ -53,3 +53,7 @@ def get_capital(country_names, raise_errors=False):
             a_country: find_capital(a_country, raise_errors)
             for a_country in country_names
         }
+
+
+def foo():
+    return 42


### PR DESCRIPTION
this seems to work - coverage reduction is shown on this PR with a red X. We should duplicate this setup for CLM so we're nudged to write tests for any new code we write.

The actual setup to make this work is in [PR 16](https://github.com/walruscorp/walrus/pull/16/files).

This PR can be rejected of course.