### PR TITLE
fix: correct badge URL and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Package and Test it](https://github.com/vineetbansal/walrus/actions/workflows/build.yml/badge.svg)](https://github.com/vineetbansal/walrus/actions/workflows/build.yml)
+[![Build Package and Test it](https://github.com/walruscorp/walrus/actions/workflows/build.yml/badge.svg)](https://github.com/walruscorp/walrus/actions/workflows/build.yml)
 
 ## Walrus
 
 This package is to try out CI/testing/python coding/tooling in an isolated project, and hopefully have one place for field notes.
 
-See also [https://github.com/walruscorp/walrus_es](https://github.com/walruscorp/walrus_es) for an avaiable plugin for this project.
+See also [https://github.com/walruscorp/walrus_es](https://github.com/walruscorp/walrus_es) for an available plugin for this project.
 
 
 ### Pre-commit


### PR DESCRIPTION
Fix two issues in README.md:

- Update badge and link URL from `vineetbansal/walrus` to `walruscorp/walrus`
- Fix typo: "avaiable" → "available"

Closes #20

Generated with [Claude Code](https://claude.ai/code)